### PR TITLE
feat: allow config from dot file in user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ If you want to make all the cuts stored in a cut list, simply press `0`.
 
 ## Config
 
-You can configure settings by creating a `config.lua` file in the same
-directory as `main.lua`. Alternatively, you can create a
-`.mpv-cut.config.lua` file in your home folder.
+You can configure settings by creating a `config.lua` file in
+`~/.config/mpv-cut` or in the same directory as `main.lua`.
 
 You can include or omit any of the following:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ CHANNEL_NAMES[2] = "COOL"
 CHANNEL = 1
 
 -- The default action
-ACTION = ACTIONS.ENCODE
+ACTION = "ENCODE"
 
 -- The action to use when making cuts from a cut list
 MAKE_CUT = ACTIONS.COPY

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ If you want to make all the cuts stored in a cut list, simply press `0`.
 ## Config
 
 You can configure settings by creating a `config.lua` file in the same
-directory as `main.lua`.
+directory as `main.lua`. Alternatively, you can create a
+`.mpv-cut.config.lua` file in your home folder.
 
 You can include or omit any of the following:
 

--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,5 @@
+mp.msg.info("MPV-CUT LOADED")
+
 utils = require "mp.utils"
 
 local function print(s)
@@ -115,17 +117,14 @@ KEY_CHANNEL_INC = "="
 KEY_CHANNEL_DEC = "-"
 KEY_MAKE_CUTS = "0"
 
-config_file = mp.command_native({"expand-path", "~/.config/mpv-cut/config.lua"})
+home_config = mp.command_native({"expand-path", "~/.config/mpv-cut/config.lua"})
 if pcall(require, "config") then
-    mp.msg.info("Loaded default config.lua module.")
-elseif pcall(dofile, config_file) then
-    mp.msg.info("Loaded config file " .. config_file .. ".")
+    mp.msg.info("Loaded config file from script dir")
+elseif pcall(dofile, home_config) then
+    mp.msg.info("Loaded config file from " .. home_config)
 else
-    mp.msg.info("No config loaded.")
+    mp.msg.info("No config loaded")
 end
-
-
-mp.msg.info("MPV-CUT LOADED.")
 
 for i, v in ipairs(CHANNEL_NAMES) do
     CHANNEL_NAMES[i] = string.gsub(v, ":", "-")

--- a/main.lua
+++ b/main.lua
@@ -115,7 +115,16 @@ KEY_CHANNEL_INC = "="
 KEY_CHANNEL_DEC = "-"
 KEY_MAKE_CUTS = "0"
 
-pcall(require, "config")
+if pcall(require, "config") then
+    mp.msg.info("Loaded config module.")
+else
+    dot_config_file = os.getenv( "HOME" ) .. "/.mpv-cut.config.lua"
+    if pcall(dofile, dot_config_file) then
+        mp.msg.info("Loaded config from dotfile.")
+    else
+        mp.msg.info("Starting with default config.")
+    end
+end
 
 mp.msg.info("MPV-CUT LOADED.")
 

--- a/main.lua
+++ b/main.lua
@@ -115,16 +115,15 @@ KEY_CHANNEL_INC = "="
 KEY_CHANNEL_DEC = "-"
 KEY_MAKE_CUTS = "0"
 
+config_file = mp.command_native({"expand-path", "~/.config/mpv-cut/config.lua"})
 if pcall(require, "config") then
-    mp.msg.info("Loaded config module.")
+    mp.msg.info("Loaded default config.lua module.")
+elseif pcall(dofile, config_file) then
+    mp.msg.info("Loaded config file " .. config_file .. ".")
 else
-    dot_config_file = os.getenv( "HOME" ) .. "/.mpv-cut.config.lua"
-    if pcall(dofile, dot_config_file) then
-        mp.msg.info("Loaded config from dotfile.")
-    else
-        mp.msg.info("Starting with default config.")
-    end
+    mp.msg.info("No config loaded.")
 end
+
 
 mp.msg.info("MPV-CUT LOADED.")
 


### PR DESCRIPTION
Hi,

thanks for this neat little tool.

I added support for doing configuration from a dot file in the user home.

Background: The README suggests to create a `config.lua` file in the clone folder, but some installation methods make it impossible to create that file. (E.g. when installing using `builtins.fetchGit` in NixOS you cannot put another file in that folder using your nix config.) Adding a dot file to your home should be possible in any setup.

Thanks,
Bert